### PR TITLE
Removes getMyIP() from server

### DIFF
--- a/discover/protocol.go
+++ b/discover/protocol.go
@@ -268,7 +268,6 @@ func (p *Protocol) validatePing(s *server.Server, from *peer.Peer, m *pb.Ping) b
 		p.log.Debugw("invalid message",
 			"type", m.Name(),
 			"from", m.GetFrom(),
-			"excpected-from", from.Address(),
 		)
 		return false
 	}

--- a/discover/protocol.go
+++ b/discover/protocol.go
@@ -268,6 +268,7 @@ func (p *Protocol) validatePing(s *server.Server, from *peer.Peer, m *pb.Ping) b
 		p.log.Debugw("invalid message",
 			"type", m.Name(),
 			"from", m.GetFrom(),
+			"excpected-from", from.Address(),
 		)
 		return false
 	}

--- a/discover/protocol_test.go
+++ b/discover/protocol_test.go
@@ -43,7 +43,7 @@ func newTestServer(t require.TestingT, name string, trans transport.Transport, l
 		MasterPeers: masters,
 	}
 	prot := New(local, cfg)
-	srv := server.Listen(local, trans, log.Named("srv"), prot)
+	srv := server.Listen(local, trans, nil, log.Named("srv"), prot)
 	prot.Start(srv)
 
 	teardown := func() {

--- a/selection/protocol_test.go
+++ b/selection/protocol_test.go
@@ -53,7 +53,7 @@ func newTest(t require.TestingT, name string, trans transport.Transport, logger 
 		SaltLifetime: DefaultSaltLifetime,
 	}
 	prot := New(local, dummyDiscovery{}, cfg)
-	srv := server.Listen(local, trans, log.Named("srv"), prot)
+	srv := server.Listen(local, trans, nil, log.Named("srv"), prot)
 	prot.Start(srv)
 
 	teardown := func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -121,7 +121,7 @@ func TestSrvEncodeDecodePing(t *testing.T) {
 	assert.Equal(t, msg, ping)
 }
 
-func newTestServer(t require.TestingT, name string, trans transport.Transport, logger *zap.SugaredLogger) (*Server, func()) {
+func newTestServer(t require.TestingT, name string, trans transport.Transport, external *string, logger *zap.SugaredLogger) (*Server, func()) {
 	log := logger.Named(name)
 	db := peer.NewMemoryDB(log.Named("db"))
 	local, err := peer.NewLocal(db)
@@ -132,7 +132,7 @@ func newTestServer(t require.TestingT, name string, trans transport.Transport, l
 	s, _ = salt.NewSalt(100 * time.Second)
 	local.SetPublicSalt(s)
 
-	srv := Listen(local, trans, logger.Named(name), HandlerFunc(handle))
+	srv := Listen(local, trans, nil, logger.Named(name), HandlerFunc(handle))
 
 	teardown := func() {
 		srv.Close()
@@ -155,9 +155,9 @@ func sendPing(s *Server, p *peer.Peer) error {
 func TestPingPong(t *testing.T) {
 	p2p := transport.P2P()
 
-	srvA, closeA := newTestServer(t, "A", p2p.A, logger)
+	srvA, closeA := newTestServer(t, "A", p2p.A, nil, logger)
 	defer closeA()
-	srvB, closeB := newTestServer(t, "B", p2p.B, logger)
+	srvB, closeB := newTestServer(t, "B", p2p.B, nil, logger)
 	defer closeB()
 
 	peerA := peer.NewPeer(srvA.Local().PublicKey(), srvA.LocalAddr())
@@ -190,9 +190,9 @@ func TestSrvPingTimeout(t *testing.T) {
 
 	p2p := transport.P2P()
 
-	srvA, closeA := newTestServer(t, "A", p2p.A, logger)
+	srvA, closeA := newTestServer(t, "A", p2p.A, nil, logger)
 	defer closeA()
-	srvB, closeB := newTestServer(t, "B", p2p.B, logger)
+	srvB, closeB := newTestServer(t, "B", p2p.B, nil, logger)
 	closeB()
 
 	peerB := peer.NewPeer(srvB.Local().PublicKey(), srvB.LocalAddr())
@@ -205,9 +205,9 @@ func TestUnexpectedPong(t *testing.T) {
 
 	p2p := transport.P2P()
 
-	srvA, closeA := newTestServer(t, "A", p2p.A, logger)
+	srvA, closeA := newTestServer(t, "A", p2p.A, nil, logger)
 	defer closeA()
-	srvB, closeB := newTestServer(t, "B", p2p.B, logger)
+	srvB, closeB := newTestServer(t, "B", p2p.B, nil, logger)
 	defer closeB()
 
 	// there should never be a Ping.Handle

--- a/simulation/main.go
+++ b/simulation/main.go
@@ -76,7 +76,7 @@ func RunSim() {
 			DropNeighbors: DropAllFlag,
 		}
 		protocol := selection.New(peer.local, disc, cfg)
-		serverMap[id] = server.Listen(peer.local, network.GetTransport(name), peer.log, protocol)
+		serverMap[id] = server.Listen(peer.local, network.GetTransport(name), nil, peer.log, protocol)
 
 		protocolMap[id] = protocol
 


### PR DESCRIPTION
This PR adds a field (externalAddr) to the server constructor, that should be used when the server is started with 0.0.0.0. Otherwise, externalAddr should be set to nil