### PR TITLE
Transport interface should return net.Addr

### DIFF
--- a/discover/protocol_test.go
+++ b/discover/protocol_test.go
@@ -30,7 +30,7 @@ func init() {
 func newTestServer(t require.TestingT, name string, trans transport.Transport, logger *zap.SugaredLogger, masters ...*peer.Peer) (*server.Server, *Protocol, func()) {
 	log := logger.Named(name)
 	db := peer.NewMemoryDB(log.Named("db"))
-	local, err := peer.NewLocal("", trans.LocalAddr(), db)
+	local, err := peer.NewLocal(trans.LocalAddr().Network(), trans.LocalAddr().String(), db)
 	require.NoError(t, err)
 
 	s, _ := salt.NewSalt(100 * time.Second)

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	// create a new local node
 	db := peer.NewPersistentDB(logger.Named("db"))
 	defer db.Close()
-	local, err := peer.NewLocal("udp", externalAddr, db)
+	local, err := peer.NewLocal(trans.LocalAddr().Network(), externalAddr, db)
 	if err != nil {
 		log.Fatalf("ListenUDP: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -124,7 +124,7 @@ func TestSrvEncodeDecodePing(t *testing.T) {
 func newTestServer(t require.TestingT, name string, trans transport.Transport, external *string, logger *zap.SugaredLogger) (*Server, func()) {
 	log := logger.Named(name)
 	db := peer.NewMemoryDB(log.Named("db"))
-	local, err := peer.NewLocal("dummy", trans.LocalAddr(), db)
+	local, err := peer.NewLocal(trans.LocalAddr().Network(), trans.LocalAddr().String(), db)
 	require.NoError(t, err)
 
 	s, _ := salt.NewSalt(100 * time.Second)

--- a/transport/chan_test.go
+++ b/transport/chan_test.go
@@ -27,14 +27,14 @@ func TestChanPacket(t *testing.T) {
 	a := network.GetTransport("A")
 	b := network.GetTransport("B")
 
-	err := a.WriteTo(testPacket, b.LocalAddr())
+	err := a.WriteTo(testPacket, b.LocalAddr().String())
 	require.NoError(t, err)
 
 	pkt, addr, err := b.ReadFrom()
 	require.NoError(t, err)
 
 	assert.Equal(t, pkt.GetData(), testPacket.GetData())
-	assert.Equal(t, addr, a.LocalAddr())
+	assert.Equal(t, addr, a.LocalAddr().String())
 }
 
 func TestChanConcurrentWrite(t *testing.T) {
@@ -60,9 +60,9 @@ func TestChanConcurrentWrite(t *testing.T) {
 	}()
 
 	wg.Add(numSender)
-	burstWriteTo(a, d.LocalAddr(), 1000, &wg)
-	burstWriteTo(b, d.LocalAddr(), 1000, &wg)
-	burstWriteTo(c, d.LocalAddr(), 1000, &wg)
+	burstWriteTo(a, d.LocalAddr().String(), 1000, &wg)
+	burstWriteTo(b, d.LocalAddr().String(), 1000, &wg)
+	burstWriteTo(c, d.LocalAddr().String(), 1000, &wg)
 
 	// wait for everything to finish
 	assert.Eventually(t, func() bool { wg.Wait(); return true }, time.Second, 10*time.Millisecond)

--- a/transport/conn.go
+++ b/transport/conn.go
@@ -58,6 +58,6 @@ func (t *TransportConn) Close() {
 }
 
 // LocalAddr returns the local network address.
-func (t *TransportConn) LocalAddr() string {
-	return t.conn.LocalAddr().String()
+func (t *TransportConn) LocalAddr() net.Addr {
+	return t.conn.LocalAddr()
 }

--- a/transport/conn_test.go
+++ b/transport/conn_test.go
@@ -24,14 +24,14 @@ func TestConnUdpPacket(t *testing.T) {
 	b := openUDP(t)
 	defer b.Close()
 
-	err := a.WriteTo(testPacket, b.LocalAddr())
+	err := a.WriteTo(testPacket, b.LocalAddr().String())
 	require.NoError(t, err)
 
 	pkt, addr, err := b.ReadFrom()
 	require.NoError(t, err)
 
 	assert.Equal(t, pkt.GetData(), testPacket.GetData())
-	assert.Equal(t, addr, a.LocalAddr())
+	assert.Equal(t, addr, a.LocalAddr().String())
 }
 
 func openUDP(t *testing.T) *TransportConn {

--- a/transport/p2p_test.go
+++ b/transport/p2p_test.go
@@ -24,12 +24,12 @@ func TestP2PPacket(t *testing.T) {
 	p2p := P2P()
 	defer p2p.Close()
 
-	err := p2p.A.WriteTo(testPacket, p2p.B.LocalAddr())
+	err := p2p.A.WriteTo(testPacket, p2p.B.LocalAddr().String())
 	require.NoError(t, err)
 
 	pkt, addr, err := p2p.B.ReadFrom()
 	require.NoError(t, err)
 
 	assert.Equal(t, pkt.GetData(), testPacket.GetData())
-	assert.Equal(t, addr, p2p.A.LocalAddr())
+	assert.Equal(t, addr, p2p.A.LocalAddr().String())
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,6 +3,8 @@
 package transport
 
 import (
+	"net"
+
 	pb "github.com/iotaledger/autopeering-sim/server/proto"
 )
 
@@ -26,8 +28,8 @@ type Transport interface {
 	// Any blocked ReadFrom or WriteTo operations will return errors.
 	Close()
 
-	// LocalAddr returns the local network address in string form.
-	LocalAddr() string
+	// LocalAddr returns the local network address.
+	LocalAddr() net.Addr
 }
 
 // transfer represents a send and contains the package and the return address.


### PR DESCRIPTION
`trans.LocalAddr()` now returns and `net.Addr` instead of string.